### PR TITLE
cmd/etrace: fail on non-X11 XDG_SESSION_TYPE

### DIFF
--- a/cmd/etrace/cmd_exec.go
+++ b/cmd/etrace/cmd_exec.go
@@ -96,6 +96,15 @@ func (x *cmdExec) Execute(args []string) error {
 		w = file
 	}
 
+	if !x.NoWindowWait {
+		// check if we are running on X11, if not then bail because we don't
+		// support graphical window waiting on wayland yet
+		sessionType := os.Getenv("XDG_SESSION_TYPE")
+		if strings.TrimSpace(strings.ToLower(sessionType)) != "x11" {
+			return fmt.Errorf("error: graphical session type %s is unsupported, only x11 is supported", sessionType)
+		}
+	}
+
 	outRes := ExecOutputResult{}
 	max := uint(1)
 	if currentCmd.Repeat > 0 {

--- a/cmd/etrace/cmd_file.go
+++ b/cmd/etrace/cmd_file.go
@@ -64,6 +64,15 @@ type FileOutputResult struct {
 }
 
 func (x *cmdFile) Execute(args []string) error {
+	if !x.NoWindowWait {
+		// check if we are running on X11, if not then bail because we don't
+		// support graphical window waiting on wayland yet
+		sessionType := os.Getenv("XDG_SESSION_TYPE")
+		if strings.TrimSpace(strings.ToLower(sessionType)) != "x11" {
+			return fmt.Errorf("error: graphical session type %s is unsupported, only x11 is supported", sessionType)
+		}
+	}
+
 	// check the output file
 	w := os.Stdout
 	if x.OutputFile != "" {


### PR DESCRIPTION
We only support X11 right now. See https://github.com/canonical/etrace/issues/12 for tracking support for other compositors