### PR TITLE
.github/workflows/snap.yml: try using glob in upload action

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -9,11 +9,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Build the snap
         uses: snapcore/action-build@v1
-      - name: Rename built snap file
-        run: |
-          sudo mv etrace*.snap etrace.snap
       - name: Uploading snap artifact
         uses: actions/upload-artifact@v1
         with:
-          name: etrace.snap
+          name: etrace*.snap
           path: etrace.snap


### PR DESCRIPTION
to test if this works to build a snap or not and eliminate the rename step