### PR TITLE
many: implement arbitrary file regex support

### DIFF
--- a/cmd/etrace/cmd_exec.go
+++ b/cmd/etrace/cmd_exec.go
@@ -509,7 +509,7 @@ func (x *cmdExec) Execute(args []string) error {
 				// make a new tabwriter to stderr
 				if !x.JSONOutput {
 					wtab := tabWriterGeneric(w)
-					slg.Display(wtab)
+					slg.Display(wtab, nil)
 				}
 			} else {
 				logError(fmt.Errorf("cannot extract runtime data: %w", straceRes.err))

--- a/cmd/etrace/cmd_file.go
+++ b/cmd/etrace/cmd_file.go
@@ -52,6 +52,7 @@ type cmdFile struct {
 	NoWindowWait      bool     `long:"no-window-wait" description:"Don't wait for the window to appear, just run until the program exits"`
 	FileRegex         string   `long:"file-regex" description:"Regular expression of files to return, if empty all files are returned"`
 	ParentDirPaths    []string `long:"parent-dirs" description:"List of parent directories matching files must be underneath to match"`
+	ShowPrograms      bool     `long:"show-programs" description:"Show programs that accessed the files"`
 
 	Args struct {
 		Cmd []string `description:"Command to run" required:"yes"`
@@ -302,10 +303,13 @@ func (x *cmdFile) Execute(args []string) error {
 	}
 
 	if !x.JSONOutput {
-		// TODO: implement "pretty/simple" output for file
 		// make a new tabwriter to stderr
 		wtab := tabWriterGeneric(w)
-		execFiles.Display(wtab)
+		opts := &strace.DisplayOptions{}
+		if !x.ShowPrograms {
+			opts.NoDisplayPrograms = true
+		}
+		execFiles.Display(wtab, opts)
 	}
 
 	if x.RestoreScript != "" {

--- a/cmd/etrace/cmd_file.go
+++ b/cmd/etrace/cmd_file.go
@@ -286,13 +286,6 @@ func (x *cmdFile) Execute(args []string) error {
 		}
 	}
 
-	// snapRevision, err := snaps.Revision(x.Args.Cmd[0])
-	// if err != nil {
-	// 	return err
-	// }
-
-	fmt.Printf("using regex pattern of %q\n", regex)
-
 	// parse the strace log
 	execFiles, err := strace.TraceExecveWithFiles(
 		straceLog,

--- a/internal/strace/commands.go
+++ b/internal/strace/commands.go
@@ -100,6 +100,13 @@ func TraceFilesCommand(straceLogPattern string, origCmd ...string) (*exec.Cmd, e
 		// this makes the strace output append </path/to/file/or/dir> wherever
 		// a file descriptor shows up
 		"-y",
+		// don't output any verbose structures as they may have strings in them
+		// that aren't files, such as:
+		// recvfrom(7<socket:[624422]>, ""..., 2048, 0, {sa_family=AF_INET, sin_port=htons(53), sin_addr=inet_addr("127.0.0.53")}, [28->16])
+		// we don't want to match 127.0.0.53, and instead with this option set
+		// we will get the much less ambiguous:
+		// recvfrom(6<socket:[644672]>, ""..., 65536, 0, 0x7f895afcc0e0, 0x7f895afcc0c0) = 68
+		"-everbose=none",
 		// since we also specify the "ff" option, this is not a verbatim
 		// filename that strace outputs to, it's now used as a pattern that
 		// strace will use to create the actual filenames, with the pid for each

--- a/internal/strace/display-opts.go
+++ b/internal/strace/display-opts.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package strace
+
+// DisplayOptions is a silly struct for passing in display options like whether
+// to display programs or just files for the file command
+// TOOD: make this go away and do it more cleanly
+type DisplayOptions struct {
+	NoDisplayPrograms bool
+}

--- a/internal/strace/exec-tracing.go
+++ b/internal/strace/exec-tracing.go
@@ -106,7 +106,7 @@ func (stt *ExecveTiming) prune() {
 }
 
 // Display shows the final exec timing output
-func (stt *ExecveTiming) Display(w io.Writer) {
+func (stt *ExecveTiming) Display(w io.Writer, opts *DisplayOptions) {
 	if len(stt.ExeRuntimes) == 0 {
 		return
 	}

--- a/internal/strace/export_test.go
+++ b/internal/strace/export_test.go
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package strace
+
+var (
+	FdAndPathRE      = fdAndPathRE
+	AbsPathWithCWDRE = absPathWithCWDRE
+	AbsPathRE        = absPathRE
+	FdRE             = fdRE
+)

--- a/internal/strace/export_test.go
+++ b/internal/strace/export_test.go
@@ -20,5 +20,6 @@ var (
 	FdAndPathRE      = fdAndPathRE
 	AbsPathWithCWDRE = absPathWithCWDRE
 	AbsPathRE        = absPathRE
+	AbsPathFirstRE   = absPathFirstRE
 	FdRE             = fdRE
 )

--- a/internal/strace/file-tracing.go
+++ b/internal/strace/file-tracing.go
@@ -62,7 +62,7 @@ var fdAndPathRE = regexp.MustCompile(
 // 121188 1574886788.027966 openat(AT_FDCWD, "/snap/chromium/958/usr/lib/locale/en_US.utf8/LC_COLLATE", O_RDONLY|O_CLOEXEC) = 3</snap/chromium/958/usr/lib/locale/aa_DJ.utf8/LC_COLLATE>
 // 120994 1574886785.937456 readlinkat(AT_FDCWD, "/snap/chromium/current", ""..., 128) = 3
 var absPathWithCWDRE = regexp.MustCompile(
-	`([0-9]+) ([0-9]+\.[0-9]+) ([a-zA-Z0-9_]+)\(AT_FDCWD,\s+\"(.*?)\".*=\s+[0-9]+(?:\s*$|x[0-9a-f]+$|<.*>$|$)`,
+	`([0-9]+) ([0-9]+\.[0-9]+) ([a-zA-Z0-9_]+)\(AT_FDCWD,\s+\"(.*?)\".*=\s+[0-9]+(?:\s*$|x[0-9a-f]+$|<\/.*>$|$)`,
 )
 
 // matches syscalls that have just a single path as any of the arguments, except

--- a/internal/strace/file-tracing.go
+++ b/internal/strace/file-tracing.go
@@ -29,6 +29,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/anonymouse64/etrace/internal/files"
@@ -252,6 +253,12 @@ func handlePathMatchElem4(trace execvePathsTracer, match []string) (bool, error)
 		return false, err
 	}
 
+	// if the match has "(deleted)" on it, trim that off because that just means
+	// strace lost track of the fd, but the app still would have used it
+	if strings.HasSuffix(match[4], "(deleted)") {
+		match[4] = strings.TrimSuffix(match[4], " (deleted)")
+	}
+
 	// add this path to the tracer's total list of paths
 	trace.addProcessPathAccess(
 		PathAccess{
@@ -277,6 +284,13 @@ func handleFdAndPathMatch(trace execvePathsTracer, match []string) (bool, error)
 
 	// for this, we need to join the fd + path
 	fullPath := filepath.Join(match[4], match[5])
+
+	// if the match has "(deleted)" on it, trim that off because that just means
+	// strace lost track of the fd, but the app still would have used it
+	if strings.HasSuffix(fullPath, "(deleted)") {
+		fullPath = strings.TrimSuffix(fullPath, " (deleted)")
+	}
+
 	trace.addProcessPathAccess(
 		PathAccess{
 			Time:    unixFloatSecondsToTime(execStart),

--- a/internal/strace/file-tracing.go
+++ b/internal/strace/file-tracing.go
@@ -449,13 +449,10 @@ func TraceExecveWithFiles(straceLogPattern string, regex *regexp.Regexp) (*Execv
 		if err == nil {
 			size = info.Size()
 		}
-		// don't include directories
-		if err == nil && !info.IsDir() {
-			trace.AllFiles = append(trace.AllFiles, FileAndSize{
-				Path: path,
-				Size: size,
-			})
-		}
+		trace.AllFiles = append(trace.AllFiles, FileAndSize{
+			Path: path,
+			Size: size,
+		})
 	}
 
 	// sort the all files by the path member for nicer formatting

--- a/internal/strace/file-tracing.go
+++ b/internal/strace/file-tracing.go
@@ -96,7 +96,7 @@ var absPathRE = regexp.MustCompile(
 // DOES NOT match these lines:
 // 27652 1587946984.879501 write(9<pipe:[200089]>, ""..., 4) = 4
 var fdRE = regexp.MustCompile(
-	`([0-9]+)\s+([0-9]+\.[0-9]+)\s+(.*)\(.*[0-9]+<(/.*?)>.*= [0-9]+(?:\s*$|x[0-9a-f]+$|<.*>$|$)`,
+	`([0-9]+)\s+([0-9]+\.[0-9]+)\s+(.*)\(.*[0-9]+<(\/.*?)>.*= [0-9]+(?:\s*$|x[0-9a-f]+$|<.*>$|$)`,
 )
 
 // PathAccess represents a single syscall accessing a file

--- a/internal/strace/file-tracing.go
+++ b/internal/strace/file-tracing.go
@@ -89,8 +89,10 @@ var absPathRE = regexp.MustCompile(
 // 121188 1574886788.028052 mmap(NULL, 1244054, PROT_READ, MAP_PRIVATE, 3</snap/chromium/958/usr/lib/locale/aa_DJ.utf8/LC_COLLATE>, 0) = 0x7f8d780a7000
 // 120990 1574886796.125850 lseek(156</snap/chromium/958/data-dir/icons/Yaru/cursors/text>, 6144, SEEK_SET) = 6144
 // 120990 1574886796.126170 read(156</snap/chromium/958/data-dir/icons/Yaru/cursors/text>, ""..., 1024) = 1024
+// DOES NOT match these lines:
+// 27652 1587946984.879501 write(9<pipe:[200089]>, ""..., 4) = 4
 var fdRE = regexp.MustCompile(
-	`([0-9]+)\s+([0-9]+\.[0-9]+)\s+(.*)\(.*[0-9]+<(.*?)>.*= [0-9]+(?:\s*$|x[0-9a-f]+$|<.*>$|$)`,
+	`([0-9]+)\s+([0-9]+\.[0-9]+)\s+(.*)\(.*[0-9]+<(/.*?)>.*= [0-9]+(?:\s*$|x[0-9a-f]+$|<.*>$|$)`,
 )
 
 // PathAccess represents a single syscall accessing a file

--- a/internal/strace/file-tracing.go
+++ b/internal/strace/file-tracing.go
@@ -180,6 +180,7 @@ func (e *ExecvePaths) Display(w io.Writer, opts *DisplayOptions) {
 	fmt.Fprintf(w, "%d files accessed during snap run:\n", len(e.AllFiles))
 
 	if opts != nil && opts.NoDisplayPrograms {
+		fmt.Fprintf(w, "\tFilename\tSize (bytes)\n")
 		// TODO: we should pass some kind of opt to TraceExecveWithFiles to
 		// instruct it not to include the programs instead of here, but oh
 		// well here we are
@@ -193,15 +194,6 @@ func (e *ExecvePaths) Display(w io.Writer, opts *DisplayOptions) {
 				continue
 			}
 			seenFiles[droppedProgramFileInfo] = true
-			if f.Size == -1 {
-				// don't output the size
-				fmt.Fprintf(w, "\t%s\t \n", f.Path)
-			} else {
-				fmt.Fprintf(w, "\t%s\t%d\n", f.Path, f.Size)
-			}
-		}
-		fmt.Fprintf(w, "\tFilename\tSize (bytes)\n")
-		for _, f := range e.AllFiles {
 			if f.Size == -1 {
 				// don't output the size
 				fmt.Fprintf(w, "\t%s\t \n", f.Path)

--- a/internal/strace/file-tracing.go
+++ b/internal/strace/file-tracing.go
@@ -48,8 +48,12 @@ import (
 // 122166 1574886795.484115 newfstatat(3</proc/122166/fd>, "9", {st_mode=S_IFREG|0644, st_size=1377694, ...}, 0) = 0
 // 121041 1574886786.247289 openat(9</snap/chromium/958>, "data-dir", O_RDONLY|O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY) = 10</snap/chromium/958/data-dir>
 // 121041 1574886786.247289 openat(9</snap/chromium/958>, "data-dir/some-sub-dir", O_RDONLY|O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY) = 10</snap/chromium/958/data-dir>
+
+// DOES NOT MATCH lines like:
+// 16513 1592352817.317842 readlinkat(4</proc/1/ns/mnt>, "", ""..., 128) = 16
+
 var fdAndPathRE = regexp.MustCompile(
-	`([0-9]+) ([0-9]+\.[0-9]+) (.*)\([0-9]+<(/.*?)>, "([^\/]?.+)".*= [0-9]+(?:\s*$|x[0-9a-f]+$|<.*>$|$)`,
+	`([0-9]+) ([0-9]+\.[0-9]+) (.*)\([0-9]+<(\/.*?)>, "([^\/\"]?[^\"]+)".*= [0-9]+(?:\s*$|x[0-9a-f]+$|<.*>$|$)`,
 )
 
 // matches syscalls that have AT_FDCWD with an absolute path as the 2nd argument

--- a/internal/strace/file-tracing.go
+++ b/internal/strace/file-tracing.go
@@ -49,7 +49,7 @@ import (
 // 121041 1574886786.247289 openat(9</snap/chromium/958>, "data-dir", O_RDONLY|O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY) = 10</snap/chromium/958/data-dir>
 // 121041 1574886786.247289 openat(9</snap/chromium/958>, "data-dir/some-sub-dir", O_RDONLY|O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY) = 10</snap/chromium/958/data-dir>
 var fdAndPathRE = regexp.MustCompile(
-	`([0-9]+) ([0-9]+\.[0-9]+) (.*)\([0-9]+<(.*?)>, "([^\/]?.+)".*= [0-9]+(?:\s*$|x[0-9a-f]+$|<.*>$|$)`,
+	`([0-9]+) ([0-9]+\.[0-9]+) (.*)\([0-9]+<(/.*?)>, "([^\/]?.+)".*= [0-9]+(?:\s*$|x[0-9a-f]+$|<.*>$|$)`,
 )
 
 // matches syscalls that have AT_FDCWD with an absolute path as the 2nd argument

--- a/internal/strace/file-tracing.go
+++ b/internal/strace/file-tracing.go
@@ -175,7 +175,7 @@ func (e *ExecvePaths) addProcessPathAccess(path PathAccess) {
 }
 
 // Display shows the final exec timing output
-func (e *ExecvePaths) Display(w io.Writer) {
+func (e *ExecvePaths) Display(w io.Writer, opts *DisplayOptions) {
 	if len(e.AllFiles) == 0 {
 		return
 	}

--- a/internal/strace/file-tracing_test.go
+++ b/internal/strace/file-tracing_test.go
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package strace_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/anonymouse64/etrace/internal/strace"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type regexpMatchSuite struct{}
+
+var _ = Suite(&regexpMatchSuite{})
+
+func (p *regexpMatchSuite) TestFdAndPathRE(c *C) {
+
+	tt := []struct {
+		line       string
+		expmatches []string
+		comment    string
+	}{
+		{
+			`122166 1574886795.484115 newfstatat(3</proc/122166/fd>, "9", {st_mode=S_IFREG|0644, st_size=1377694, ...}, 0) = 0`,
+			[]string{
+				"122166",
+				"1574886795.484115",
+				"newfstatat",
+				"/proc/122166/fd",
+				"9",
+			},
+			"second arg number",
+		},
+		{
+			`121041 1574886786.247289 openat(9</snap/chromium/958>, "data-dir", O_RDONLY|O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY) = 10</snap/chromium/958/data-dir>`,
+			[]string{
+				"121041",
+				"1574886786.247289",
+				"openat",
+				"/snap/chromium/958",
+				"data-dir",
+			},
+			"second arg name",
+		},
+		{
+			`121041 1574886786.247289 openat(9</snap/chromium/958>, "data-dir/some-sub-dir", O_RDONLY|O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY) = 10</snap/chromium/958/data-dir>`,
+			[]string{
+				"121041",
+				"1574886786.247289",
+				"openat",
+				"/snap/chromium/958",
+				"data-dir/some-sub-dir",
+			},
+			"second arg path with sub-dir",
+		},
+	}
+
+	for _, t := range tt {
+		matches := strace.FdAndPathRE.FindStringSubmatch(t.line)
+		c.Check(
+			matches,
+			DeepEquals,
+			// the first argument should be the whole line itself
+			append([]string{t.line}, t.expmatches...),
+			Commentf(t.comment),
+		)
+	}
+}
+
+func (p *regexpMatchSuite) TestAbsPathWithCWDRE(c *C) {
+
+	tt := []struct {
+		line       string
+		expmatches []string
+		comment    string
+	}{
+		{
+			`121188 1574886788.027891 openat(AT_FDCWD, "/snap/chromium/current/usr/lib/locale/en_US.UTF-8/LC_COLLATE", O_RDONLY|O_CLOEXEC) = 4</some/where>`,
+			[]string{
+				"121188",
+				"1574886788.027891",
+				"openat",
+				"/snap/chromium/current/usr/lib/locale/en_US.UTF-8/LC_COLLATE",
+			},
+			"syscall with returned fd path testcase 1",
+		},
+		{
+			`121188 1574886788.027966 openat(AT_FDCWD, "/snap/chromium/958/usr/lib/locale/en_US.utf8/LC_COLLATE", O_RDONLY|O_CLOEXEC) = 3</snap/chromium/958/usr/lib/locale/aa_DJ.utf8/LC_COLLATE>`,
+			[]string{
+				"121188",
+				"1574886788.027966",
+				"openat",
+				"/snap/chromium/958/usr/lib/locale/en_US.utf8/LC_COLLATE",
+			},
+			"syscall with returned fd path testcase 2",
+		},
+		{
+			`120994 1574886785.937456 readlinkat(AT_FDCWD, "/snap/chromium/current", ""..., 128) = 3`,
+			[]string{
+				"120994",
+				"1574886785.937456",
+				"readlinkat",
+				"/snap/chromium/current",
+			},
+			"syscall without returned fd path",
+		},
+	}
+
+	for _, t := range tt {
+		matches := strace.AbsPathWithCWDRE.FindStringSubmatch(t.line)
+		c.Check(
+			matches,
+			DeepEquals,
+			// the first argument should be the whole line itself
+			append([]string{t.line}, t.expmatches...),
+			Commentf(t.comment),
+		)
+	}
+}
+
+func (p *regexpMatchSuite) TestAbsPathRE(c *C) {
+
+	tt := []struct {
+		line       string
+		expmatches []string
+		comment    string
+	}{
+		// TODO: fix this case
+		// {
+		// 	`121372 1574886788.833540 symlinkat("/snap/chromium/958/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules/im-am-et.so", AT_FDCWD, "/home/ijohnson/snap/chromium/common/.cache/immodules/im-am-et.so") = 0`,
+		// 	[]string{
+		// 		"121372",
+		// 		"1574886788.833540",
+		// 		"symlinkat",
+		// 		"AT_FDCWD",
+		// 		"/home/ijohnson/snap/chromium/common/.cache/immodules/im-am-et.so",
+		// 	},
+		// 	"symlinkat",
+		// },
+		{
+			`121185 1574886787.979943 execve("/snap/chromium/958/usr/sbin/update-icon-caches", [...], 0x561bce4ee880 /* 105 vars */) = 0`,
+			[]string{
+				"121185",
+				"1574886787.979943",
+				"execve",
+				"/snap/chromium/958/usr/sbin/update-icon-caches",
+			},
+			"execve syscall",
+		},
+		{
+			`120990 1574886792.229066 readlink("/snap/chromium/958/etc/fonts/conf.d/65-nonlatin.conf", ""..., 4095) = 30`,
+			[]string{
+				"120990",
+				"1574886792.229066",
+				"readlink",
+				"/snap/chromium/958/etc/fonts/conf.d/65-nonlatin.conf",
+			},
+			"readlink syscall",
+		},
+		// TODO: fix this case
+		// {
+		// 	`121041 1574886786.249939 mount("tmpfs", "/snap/chromium/958/data-dir/icons", ""..., 0, ""...) = 0`,
+		// 	[]string{
+		// 		"121041",
+		// 		"1574886786.249939",
+		// 		"mount",
+		// 		"/snap/chromium/958/data-dir/icons",
+		// 	},
+		// 	"mount syscall",
+		// },
+	}
+
+	for _, t := range tt {
+		matches := strace.AbsPathRE.FindStringSubmatch(t.line)
+		c.Check(
+			matches,
+			DeepEquals,
+			// the first argument should be the whole line itself
+			append([]string{t.line}, t.expmatches...),
+			Commentf(t.comment),
+		)
+	}
+}

--- a/internal/strace/file-tracing_test.go
+++ b/internal/strace/file-tracing_test.go
@@ -30,13 +30,14 @@ type regexpMatchSuite struct{}
 
 var _ = Suite(&regexpMatchSuite{})
 
-func (p *regexpMatchSuite) TestFdAndPathRE(c *C) {
+type regexSyscallTestCase struct {
+	line       string
+	expmatches []string
+	comment    string
+}
 
-	tt := []struct {
-		line       string
-		expmatches []string
-		comment    string
-	}{
+func (p *regexpMatchSuite) TestFdAndPathRE(c *C) {
+	tt := []regexSyscallTestCase{
 		{
 			`122166 1574886795.484115 newfstatat(3</proc/122166/fd>, "9", {st_mode=S_IFREG|0644, st_size=1377694, ...}, 0) = 0`,
 			[]string{
@@ -85,12 +86,7 @@ func (p *regexpMatchSuite) TestFdAndPathRE(c *C) {
 }
 
 func (p *regexpMatchSuite) TestAbsPathWithCWDRE(c *C) {
-
-	tt := []struct {
-		line       string
-		expmatches []string
-		comment    string
-	}{
+	tt := []regexSyscallTestCase{
 		{
 			`121188 1574886788.027891 openat(AT_FDCWD, "/snap/chromium/current/usr/lib/locale/en_US.UTF-8/LC_COLLATE", O_RDONLY|O_CLOEXEC) = 4</some/where>`,
 			[]string{
@@ -136,12 +132,43 @@ func (p *regexpMatchSuite) TestAbsPathWithCWDRE(c *C) {
 }
 
 func (p *regexpMatchSuite) TestAbsPathRE(c *C) {
+	tt := []regexSyscallTestCase{
+		{
+			`25251 1588799883.286400 newfstatat(-1, "/sys/kernel/security/apparmor/features", 0x7ffe17b21970, 0) = 0`,
+			[]string{
+				"25251",
+				"1588799883.286400",
+				"newfstatat",
+				"/sys/kernel/security/apparmor/features",
+			},
+			"newfstatat syscall",
+		},
+		{
+			`26004 1588121137.500643 recvfrom(7<socket:[624422]>, ""..., 2048, 0, {sa_family=AF_INET, sin_port=htons(53), sin_addr=inet_addr("127.0.0.53")}, [28->16]) = 84`,
+			[]string{},
+			"not matching recvfrom",
+		},
+	}
 
-	tt := []struct {
-		line       string
-		expmatches []string
-		comment    string
-	}{
+	for _, t := range tt {
+		matches := strace.AbsPathRE.FindStringSubmatch(t.line)
+		// the first argument should be the whole line itself for positive
+		// matches
+		var exp []string
+		if len(t.expmatches) != 0 {
+			exp = append([]string{t.line}, t.expmatches...)
+		}
+		c.Check(
+			matches,
+			DeepEquals,
+			exp,
+			Commentf(t.comment),
+		)
+	}
+}
+
+func (p *regexpMatchSuite) TestAbsPathFirstRE(c *C) {
+	tt := []regexSyscallTestCase{
 		// TODO: fix this case
 		// {
 		// 	`121372 1574886788.833540 symlinkat("/snap/chromium/958/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules/im-am-et.so", AT_FDCWD, "/home/ijohnson/snap/chromium/common/.cache/immodules/im-am-et.so") = 0`,
@@ -174,27 +201,118 @@ func (p *regexpMatchSuite) TestAbsPathRE(c *C) {
 			},
 			"readlink syscall",
 		},
-		// TODO: fix this case
-		// {
-		// 	`121041 1574886786.249939 mount("tmpfs", "/snap/chromium/958/data-dir/icons", ""..., 0, ""...) = 0`,
-		// 	[]string{
-		// 		"121041",
-		// 		"1574886786.249939",
-		// 		"mount",
-		// 		"/snap/chromium/958/data-dir/icons",
-		// 	},
-		// 	"mount syscall",
-		// },
+		{
+			`15546 1588797314.955495 readlink("/proc/self/fd/3", ""..., 4096) = 25`,
+			[]string{
+				"15546",
+				"1588797314.955495",
+				"readlink",
+				"/proc/self/fd/3",
+			},
+			"another readlink syscall",
+		},
 	}
 
 	for _, t := range tt {
-		matches := strace.AbsPathRE.FindStringSubmatch(t.line)
+		matches := strace.AbsPathFirstRE.FindStringSubmatch(t.line)
+		// the first argument should be the whole line itself for positive
+		// matches
+		var exp []string
+		if len(t.expmatches) != 0 {
+			exp = append([]string{t.line}, t.expmatches...)
+		}
 		c.Check(
 			matches,
 			DeepEquals,
-			// the first argument should be the whole line itself
-			append([]string{t.line}, t.expmatches...),
+			exp,
 			Commentf(t.comment),
 		)
+	}
+}
+
+func (p *regexpMatchSuite) TestfdRE(c *C) {
+	tt := []regexSyscallTestCase{
+		{
+			`121041 1574886786.247289 openat(9</snap/chromium/958>, "data-dir", O_RDONLY|O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY) = 10</snap/chromium/958/data-dir>`,
+			[]string{
+				"121041",
+				"1574886786.247289",
+				"openat",
+				"/snap/chromium/958",
+			},
+			"",
+		},
+		{
+			`121188 1574886788.028095 close(3</snap/chromium/958/usr/lib/locale/aa_DJ.utf8/LC_COLLATE>) = 0`,
+			[]string{
+				"121188",
+				"1574886788.028095",
+				"close",
+				"/snap/chromium/958/usr/lib/locale/aa_DJ.utf8/LC_COLLATE",
+			},
+			"",
+		},
+		{
+			`121188 1574886788.028052 mmap(NULL, 1244054, PROT_READ, MAP_PRIVATE, 3</snap/chromium/958/usr/lib/locale/aa_DJ.utf8/LC_COLLATE>, 0) = 0x7f8d780a7000`,
+			[]string{
+				"121188",
+				"1574886788.028052",
+				"mmap",
+				"/snap/chromium/958/usr/lib/locale/aa_DJ.utf8/LC_COLLATE",
+			},
+			"",
+		},
+		{
+			`120990 1574886796.125850 lseek(156</snap/chromium/958/data-dir/icons/Yaru/cursors/text>, 6144, SEEK_SET) = 6144`,
+			[]string{
+				"120990",
+				"1574886796.125850",
+				"lseek",
+				"/snap/chromium/958/data-dir/icons/Yaru/cursors/text",
+			},
+			"",
+		},
+		{
+			`120990 1574886796.126170 read(156</snap/chromium/958/data-dir/icons/Yaru/cursors/text>, ""..., 1024) = 1024`,
+			[]string{
+				"120990",
+				"1574886796.126170",
+				"read",
+				"/snap/chromium/958/data-dir/icons/Yaru/cursors/text",
+			},
+			"read",
+		},
+		{
+			`20721 1592353878.163963 ftruncate(26</tmp/.glDNftWu (deleted)>, 8192) = 0`,
+			[]string{
+				"20721",
+				"1592353878.163963",
+				"ftruncate",
+				"/tmp/.glDNftWu (deleted)",
+			},
+			"ftruncate with deleted fd",
+		},
+		// negative cases we expect not to match
+		{
+			`27652 1587946984.879501 write(9<pipe:[200089]>, ""..., 4) = 4`,
+			[]string{},
+			"",
+		},
+		{
+			`25251 1588799883.286429 openat(-1, "/sys/kernel/security/apparmor/features", O_RDONLY|O_CLOEXEC|O_DIRECTORY) = 3</sys/kernel/security/apparmor/features>`,
+			[]string{},
+			"openat is handled by absPathRE",
+		},
+	}
+
+	for _, t := range tt {
+		matches := strace.FdRE.FindStringSubmatch(t.line)
+		// the first argument should be the whole line itself for positive
+		// matches
+		var exp []string
+		if len(t.expmatches) != 0 {
+			exp = append([]string{t.line}, t.expmatches...)
+		}
+		c.Check(matches, DeepEquals, exp, Commentf(t.comment))
 	}
 }


### PR DESCRIPTION
New features include:
- [x] Better tracking of files accesses, meaning more files are shown as accessed
- [x] Better unit testing of the file accesses tracked by etrace

For the default non-JSON output of the file subcommand, the following new features have been implemented:
- [x] New option `--file-regex` for arbitrary file access regex
- [x] New option `--parent-dirs` for specifying what parent directories files accessed should be filtered from (i.e. only files underneath dir `/usr/lib/`)
- [x] New option `--program-regex` for specifying what program/processes should have their file accesses tracked
- [x] New option `--include-snapd-programs` for specifying to include accesses made by snapd before the actual application starts running
- [x] New options `--show-programs` for showing what programs accessed what file

Fixes: https://github.com/canonical/etrace/issues/5