### PR TITLE
internal/profiling/profiling: fix error in dropping caches

### DIFF
--- a/internal/profiling/profiling.go
+++ b/internal/profiling/profiling.go
@@ -18,6 +18,7 @@
 package profiling
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -36,7 +37,7 @@ func FreeCaches() error {
 	// calling user, which means we need to do setuid or user priv dropping ...
 	// so just use sudo for now
 	for _, i := range []int{1, 2, 3} {
-		out, err := execCommandCombinedOutput("sudo", "sysctl", "-q", "vm.drop_caches="+string(i))
+		out, err := execCommandCombinedOutput("sudo", "sysctl", "-q", fmt.Sprintf("vm.drop_caches=%d", i))
 		if err != nil {
 			log.Println(string(out))
 			return err

--- a/internal/profiling/profiling_test.go
+++ b/internal/profiling/profiling_test.go
@@ -122,11 +122,11 @@ func (p *profilingTestSuite) TestFreeCaches(c *check.C) {
 		c.Assert(exec, check.Equals, "sudo")
 		switch runs {
 		case 0:
-			c.Assert(args, check.DeepEquals, []string{"sysctl", "-q", "vm.drop_caches=\x01"})
+			c.Assert(args, check.DeepEquals, []string{"sysctl", "-q", "vm.drop_caches=1"})
 		case 1:
-			c.Assert(args, check.DeepEquals, []string{"sysctl", "-q", "vm.drop_caches=\x02"})
+			c.Assert(args, check.DeepEquals, []string{"sysctl", "-q", "vm.drop_caches=2"})
 		case 2:
-			c.Assert(args, check.DeepEquals, []string{"sysctl", "-q", "vm.drop_caches=\x03"})
+			c.Assert(args, check.DeepEquals, []string{"sysctl", "-q", "vm.drop_caches=3"})
 		default:
 			c.Fatalf(
 				"unexpected exec call of %v (on %d calls)",


### PR DESCRIPTION
This was producing something like

```
$ sudo sysctl -q vm.drop_caches=\x01
```

which is wrong, it should be

```
$ sudo sysctl -q vm.drop_caches=1
```

This was missed since sysctl doesn't actually report the error:

```bash

$ sudo sysctl -q vm.drop_caches=\x01
sysctl: setting key "vm.drop_caches": Invalid argument
$ echo $?
0
```

Signed-off-by: Ian Johnson <ian.johnson@canonical.com>