### PR TITLE
cmd/etrace: stop using wmctrl, misc error handling cleanup

### DIFF
--- a/cmd/etrace/cmd_exec.go
+++ b/cmd/etrace/cmd_exec.go
@@ -399,7 +399,6 @@ func (x *cmdExec) Execute(args []string) error {
 		xtool := xdotool.MakeXDoTool()
 
 		tryXToolClose := true
-		tryWmctrl := false
 		var wids []string
 
 		windowspec := xdotool.Window{}
@@ -460,7 +459,6 @@ func (x *cmdExec) Execute(args []string) error {
 				pid, err := xtool.PidForWindowID(wid)
 				if err != nil {
 					logError(fmt.Errorf("getting pid for wid %s: %w", wid, err))
-					tryWmctrl = true
 					break
 				}
 				pids[i] = pid
@@ -471,7 +469,6 @@ func (x *cmdExec) Execute(args []string) error {
 				err = xtool.CloseWindowID(wid)
 				if err != nil {
 					logError(fmt.Errorf("closing window: %w", err))
-					tryWmctrl = true
 				}
 			}
 
@@ -483,16 +480,8 @@ func (x *cmdExec) Execute(args []string) error {
 					// if the process already exited then try wmctrl
 					if !strings.Contains(err.Error(), "process already finished") {
 						logError(fmt.Errorf("killing window process pid %d: %w", pid, err))
-						tryWmctrl = true
 					}
 				}
-			}
-		}
-
-		if tryWmctrl {
-			err = wmctrlCloseWindow(x.WindowName)
-			if err != nil {
-				logError(fmt.Errorf("closing window with wmctrl: %w", err))
 			}
 		}
 

--- a/cmd/etrace/cmd_exec.go
+++ b/cmd/etrace/cmd_exec.go
@@ -421,17 +421,19 @@ func (x *cmdExec) Execute(args []string) error {
 
 		// before running the final command, free the caches to get most accurate
 		// timing
-		err := profiling.FreeCaches()
-		if err != nil {
+		if err := profiling.FreeCaches(); err != nil {
 			return err
 		}
 
 		// start running the command
 		start := time.Now()
-		err = cmd.Start()
+		if err := cmd.Start(); err != nil {
+			return err
+		}
 
 		if !x.NoWindowWait {
 			// now wait until the window appears
+			var err error
 			wids, err = xtool.WaitForWindow(windowspec)
 			if err != nil {
 				logError(fmt.Errorf("waiting for window appearance: %w", err))
@@ -466,8 +468,7 @@ func (x *cmdExec) Execute(args []string) error {
 
 			// close the windows
 			for _, wid := range wids {
-				err = xtool.CloseWindowID(wid)
-				if err != nil {
+				if err := xtool.CloseWindowID(wid); err != nil {
 					logError(fmt.Errorf("closing window: %w", err))
 				}
 			}

--- a/cmd/etrace/cmd_file.go
+++ b/cmd/etrace/cmd_file.go
@@ -262,14 +262,16 @@ func (x *cmdFile) Execute(args []string) error {
 
 	// before running the final command, free the caches to get most accurate
 	// timing
-	err = profiling.FreeCaches()
-	if err != nil {
+
+	if err := profiling.FreeCaches(); err != nil {
 		return err
 	}
 
 	// start running the command
 	start := time.Now()
-	err = cmd.Start()
+	if err := cmd.Start(); err != nil {
+		return err
+	}
 
 	if x.NoWindowWait {
 		// if we aren't waiting on the window class, then just wait for the
@@ -303,8 +305,7 @@ func (x *cmdFile) Execute(args []string) error {
 
 		// close the windows
 		for _, wid := range wids {
-			err = xtool.CloseWindowID(wid)
-			if err != nil {
+			if err := xtool.CloseWindowID(wid); err != nil {
 				logError(fmt.Errorf("closing window: %w", err))
 			}
 		}

--- a/cmd/etrace/cmd_file.go
+++ b/cmd/etrace/cmd_file.go
@@ -240,7 +240,6 @@ func (x *cmdFile) Execute(args []string) error {
 	xtool := xdotool.MakeXDoTool()
 
 	tryXToolClose := true
-	tryWmctrl := false
 	var wids []string
 
 	windowspec := xdotool.Window{}
@@ -297,7 +296,6 @@ func (x *cmdFile) Execute(args []string) error {
 			pid, err := xtool.PidForWindowID(wid)
 			if err != nil {
 				logError(fmt.Errorf("getting pid for wid %s: %w", wid, err))
-				tryWmctrl = true
 				break
 			}
 			pids[i] = pid
@@ -308,7 +306,6 @@ func (x *cmdFile) Execute(args []string) error {
 			err = xtool.CloseWindowID(wid)
 			if err != nil {
 				logError(fmt.Errorf("closing window: %w", err))
-				tryWmctrl = true
 			}
 		}
 
@@ -320,16 +317,8 @@ func (x *cmdFile) Execute(args []string) error {
 				// if the process already exited then try wmctrl
 				if !strings.Contains(err.Error(), "process already finished") {
 					logError(fmt.Errorf("killing window process pid %d: %w", pid, err))
-					tryWmctrl = true
 				}
 			}
-		}
-	}
-
-	if tryWmctrl {
-		err = wmctrlCloseWindow(x.WindowName)
-		if err != nil {
-			logError(fmt.Errorf("closing window with wmctrl: %w", err))
 		}
 	}
 

--- a/cmd/etrace/main.go
+++ b/cmd/etrace/main.go
@@ -113,16 +113,6 @@ func tabWriterGeneric(w io.Writer) *tabwriter.Writer {
 	return tabwriter.NewWriter(w, 5, 3, 2, ' ', 0)
 }
 
-// TODO: move to an internal pkg, maybe commands or generalize xdotool?
-func wmctrlCloseWindow(name string) error {
-	out, err := exec.Command("wmctrl", "-c", name).CombinedOutput()
-	if err != nil {
-		log.Println(string(out))
-		return err
-	}
-	return nil
-}
-
 var errs []error
 
 func resetErrors() {


### PR DESCRIPTION
This is less code and slightly more readable. Also add a missing error check on
cmd.Start().