### PR TITLE
.github/workflows/go.yml: only run on PR's and pushes to master

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,9 @@
 name: Go
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 jobs:
   build:
     name: Go unit tests

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,5 +1,9 @@
 name: Snap
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 jobs:
   build-snap:
     name: Snap building


### PR DESCRIPTION
Running on branches isn't super useful to us right now.