### PR TITLE
cmd/etrace: move common options to main.go base command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,31 +37,33 @@ Usage:
   etrace [OPTIONS] exec [exec-OPTIONS] Cmd...
 
 Application Options:
-  -e, --errors                   Show errors as they happen
-  -n, --repeat=                  Number of times to repeat each task
+  -e, --errors                    Show errors as they happen
+  -n, --repeat=                   Number of times to repeat each task
+  -w, --window-name=              Window name to wait for
+  -p, --prepare-script=           Script to run to prepare a run
+      --prepare-script-args=      Args to provide to the prepare script
+  -r, --restore-script=           Script to run to restore after a run
+      --restore-script-args=      Args to provide to the restore script
+  -v, --keep-vm-caches            Don't free VM caches before executing
+  -c, --class-name=               Window class to use with xdotool instead of the the first Command
+  -s, --use-snap-run              Run command through snap run
+  -d, --discard-snap-ns           Discard the snap namespace before running the snap
+      --cmd-stdout=               Log file for run command's stdout
+      --cmd-stderr=               Log file for run command's stderr
+  -j, --json                      Output results in JSON
+  -o, --output-file=              A file to output the results (empty string means stdout)
+      --no-window-wait            Don't wait for the window to appear, just run until the program exits
 
 Help Options:
-  -h, --help                     Show this help message
+  -h, --help                      Show this help message
 
 [exec command options]
-      -w, --window-name=         Window name to wait for
-      -p, --prepare-script=      Script to run to prepare a run
-          --prepare-script-args= Args to provide to the prepare script
-      -r, --restore-script=      Script to run to restore after a run
-          --restore-script-args= Args to provide to the restore script
-      -c, --class-name=          Window class to use with xdotool instead of the the first Command
-      -t, --no-trace             Don't trace the process, just time the total execution
-      -s, --use-snap-run         Run command through snap run
-      -d, --discard-snap-ns      Discard the snap namespace before running the snap
-          --cmd-stdout=          Log file for run command's stdout
-          --cmd-stderr=          Log file for run command's stderr
-      -j, --json                 Output results in JSON
-      -o, --output-file=         A file to output the results (empty string means stdout)
-          --no-window-wait       Don't wait for the window to appear, just run until the program exits
+      -t, --no-trace              Don't trace the process, just time the total execution
+          --clean-snap-user-data  Delete snap user data before executing and restore after execution
+          --reinstall-snap        Reinstall the snap before executing, restoring any existing interface connections for the snap
 
 [exec command arguments]
-  Cmd:                           Command to run
-
+  Cmd:                            Command to run
 ```
 
 ### `file` subcommand
@@ -75,30 +77,35 @@ Usage:
   etrace [OPTIONS] file [file-OPTIONS] Cmd...
 
 Application Options:
-  -e, --errors                   Show errors as they happen
-  -n, --repeat=                  Number of times to repeat each task
+  -e, --errors                      Show errors as they happen
+  -n, --repeat=                     Number of times to repeat each task
+  -w, --window-name=                Window name to wait for
+  -p, --prepare-script=             Script to run to prepare a run
+      --prepare-script-args=        Args to provide to the prepare script
+  -r, --restore-script=             Script to run to restore after a run
+      --restore-script-args=        Args to provide to the restore script
+  -v, --keep-vm-caches              Don't free VM caches before executing
+  -c, --class-name=                 Window class to use with xdotool instead of the the first Command
+  -s, --use-snap-run                Run command through snap run
+  -d, --discard-snap-ns             Discard the snap namespace before running the snap
+      --cmd-stdout=                 Log file for run command's stdout
+      --cmd-stderr=                 Log file for run command's stderr
+  -j, --json                        Output results in JSON
+  -o, --output-file=                A file to output the results (empty string means stdout)
+      --no-window-wait              Don't wait for the window to appear, just run until the program exits
 
 Help Options:
-  -h, --help                     Show this help message
+  -h, --help                        Show this help message
 
 [file command options]
-      -w, --window-name=         Window name to wait for
-      -p, --prepare-script=      Script to run to prepare a run
-          --prepare-script-args= Args to provide to the prepare script
-      -r, --restore-script=      Script to run to restore after a run
-          --restore-script-args= Args to provide to the restore script
-      -c, --class-name=          Window class to use with xdotool instead of the the first Command
-      -s, --use-snap-run         Run command through snap run
-      -d, --discard-snap-ns      Discard the snap namespace before running the snap
-          --cmd-stdout=          Log file for run command's stdout
-          --cmd-stderr=          Log file for run command's stderr
-      -j, --json                 Output results in JSON
-      -o, --output-file=         A file to output the results (empty string means stdout)
-          --no-window-wait       Don't wait for the window to appear, just run until the program exits
+          --file-regex=             Regular expression of files to return, if empty all files are returned
+          --parent-dirs=            List of parent directories matching files must be underneath to match
+          --program-regex=          Regular expression of programs whose file accesses should be returned
+          --include-snapd-programs  Include snapd programs whose file accesses match in the list of files accessed
+          --show-programs           Show programs that accessed the files
 
 [file command arguments]
-  Cmd:                           Command to run
-
+  Cmd:                              Command to run
 ```
 
 

--- a/cmd/etrace/main.go
+++ b/cmd/etrace/main.go
@@ -37,6 +37,20 @@ type Command struct {
 	Exec       cmdExec `command:"exec" description:"Trace the program executions from a program"`
 	ShowErrors bool    `short:"e" long:"errors" description:"Show errors as they happen"`
 	Repeat     uint    `short:"n" long:"repeat" description:"Number of times to repeat each task"`
+	WindowName           string   `short:"w" long:"window-name" description:"Window name to wait for"`
+	PrepareScript        string   `short:"p" long:"prepare-script" description:"Script to run to prepare a run"`
+	PrepareScriptArgs    []string `long:"prepare-script-args" description:"Args to provide to the prepare script"`
+	RestoreScript        string   `short:"r" long:"restore-script" description:"Script to run to restore after a run"`
+	RestoreScriptArgs    []string `long:"restore-script-args" description:"Args to provide to the restore script"`
+	KeepVMCaches         bool     `short:"v" long:"keep-vm-caches" description:"Don't free VM caches before executing"`
+	WindowClass          string   `short:"c" long:"class-name" description:"Window class to use with xdotool instead of the the first Command"`
+	RunThroughSnap    bool     `short:"s" long:"use-snap-run" description:"Run command through snap run"`
+	DiscardSnapNs     bool     `short:"d" long:"discard-snap-ns" description:"Discard the snap namespace before running the snap"`
+	ProgramStdoutLog  string   `long:"cmd-stdout" description:"Log file for run command's stdout"`
+	ProgramStderrLog  string   `long:"cmd-stderr" description:"Log file for run command's stderr"`
+	JSONOutput        bool     `short:"j" long:"json" description:"Output results in JSON"`
+	OutputFile        string   `short:"o" long:"output-file" description:"A file to output the results (empty string means stdout)"`
+	NoWindowWait      bool     `long:"no-window-wait" description:"Don't wait for the window to appear, just run until the program exits"`
 }
 
 // The current input command


### PR DESCRIPTION
This reduces some duplication and also makes the help messages more concise
about specific options for each subcommand.