### PR TITLE
cmd/etrace: mv repeat arg to exec command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Usage:
 
 Application Options:
   -e, --errors                    Show errors as they happen
-  -n, --repeat=                   Number of times to repeat each task
   -w, --window-name=              Window name to wait for
   -p, --prepare-script=           Script to run to prepare a run
       --prepare-script-args=      Args to provide to the prepare script
@@ -61,6 +60,7 @@ Help Options:
       -t, --no-trace              Don't trace the process, just time the total execution
           --clean-snap-user-data  Delete snap user data before executing and restore after execution
           --reinstall-snap        Reinstall the snap before executing, restoring any existing interface connections for the snap
+      -n, --repeat=               Number of times to repeat each task
 
 [exec command arguments]
   Cmd:                            Command to run
@@ -78,7 +78,6 @@ Usage:
 
 Application Options:
   -e, --errors                      Show errors as they happen
-  -n, --repeat=                     Number of times to repeat each task
   -w, --window-name=                Window name to wait for
   -p, --prepare-script=             Script to run to prepare a run
       --prepare-script-args=        Args to provide to the prepare script

--- a/cmd/etrace/cmd_exec.go
+++ b/cmd/etrace/cmd_exec.go
@@ -59,6 +59,7 @@ type cmdExec struct {
 	NoTrace           bool `short:"t" long:"no-trace" description:"Don't trace the process, just time the total execution"`
 	CleanSnapUserData bool `long:"clean-snap-user-data" description:"Delete snap user data before executing and restore after execution"`
 	ReinstallSnap     bool `long:"reinstall-snap" description:"Reinstall the snap before executing, restoring any existing interface connections for the snap"`
+	Repeat            uint `short:"n" long:"repeat" description:"Number of times to repeat each task"`
 
 	Args struct {
 		Cmd []string `description:"Command to run" required:"yes"`
@@ -94,8 +95,8 @@ func (x *cmdExec) Execute(args []string) error {
 
 	outRes := ExecOutputResult{}
 	max := uint(1)
-	if currentCmd.Repeat > 0 {
-		max = currentCmd.Repeat
+	if x.Repeat > 0 {
+		max = x.Repeat
 	}
 
 	// TODO: ensure the snap is installed if the option --use-snap-run is set

--- a/cmd/etrace/main.go
+++ b/cmd/etrace/main.go
@@ -36,7 +36,6 @@ type Command struct {
 	File       cmdFile `command:"file" description:"Trace files accessed from a program"`
 	Exec       cmdExec `command:"exec" description:"Trace the program executions from a program"`
 	ShowErrors bool    `short:"e" long:"errors" description:"Show errors as they happen"`
-	Repeat     uint    `short:"n" long:"repeat" description:"Number of times to repeat each task"`
 	WindowName           string   `short:"w" long:"window-name" description:"Window name to wait for"`
 	PrepareScript        string   `short:"p" long:"prepare-script" description:"Script to run to prepare a run"`
 	PrepareScriptArgs    []string `long:"prepare-script-args" description:"Args to provide to the prepare script"`


### PR DESCRIPTION
It's not really useful for the file command, so move it to just be for the exec
command. This makes the help output for file less cluttered.