### PR TITLE
cmd/etrace: add --use-flatpak-run option to exec

### DIFF
--- a/cmd/etrace/cmd_file.go
+++ b/cmd/etrace/cmd_file.go
@@ -57,6 +57,9 @@ type FileOutputResult struct {
 }
 
 func (x *cmdFile) Execute(args []string) error {
+	if currentCmd.RunThroughFlatpak {
+		return fmt.Errorf("file tracing with flatpak not yet supported")
+	}
 	if !currentCmd.NoWindowWait {
 		// check if we are running on X11, if not then bail because we don't
 		// support graphical window waiting on wayland yet
@@ -245,6 +248,9 @@ func (x *cmdFile) Execute(args []string) error {
 	} else if currentCmd.WindowName != "" {
 		// then window name
 		windowspec.Name = currentCmd.WindowName
+	} else if currentCmd.WindowClassName != "" {
+		// then window class name
+		windowspec.ClassName = currentCmd.WindowClassName
 	} else {
 		// finally fall back to base cmd as the class
 		// note we use the original command and note the processed targetCmd

--- a/cmd/etrace/main.go
+++ b/cmd/etrace/main.go
@@ -33,17 +33,19 @@ import (
 
 // Command is the command for the runner
 type Command struct {
-	File       cmdFile `command:"file" description:"Trace files accessed from a program"`
-	Exec       cmdExec `command:"exec" description:"Trace the program executions from a program"`
-	ShowErrors bool    `short:"e" long:"errors" description:"Show errors as they happen"`
-	WindowName           string   `short:"w" long:"window-name" description:"Window name to wait for"`
-	PrepareScript        string   `short:"p" long:"prepare-script" description:"Script to run to prepare a run"`
-	PrepareScriptArgs    []string `long:"prepare-script-args" description:"Args to provide to the prepare script"`
-	RestoreScript        string   `short:"r" long:"restore-script" description:"Script to run to restore after a run"`
-	RestoreScriptArgs    []string `long:"restore-script-args" description:"Args to provide to the restore script"`
-	KeepVMCaches         bool     `short:"v" long:"keep-vm-caches" description:"Don't free VM caches before executing"`
-	WindowClass          string   `short:"c" long:"class-name" description:"Window class to use with xdotool instead of the the first Command"`
+	File              cmdFile  `command:"file" description:"Trace files accessed from a program"`
+	Exec              cmdExec  `command:"exec" description:"Trace the program executions from a program"`
+	ShowErrors        bool     `short:"e" long:"errors" description:"Show errors as they happen"`
+	WindowName        string   `short:"w" long:"window-name" description:"Window name to wait for"`
+	PrepareScript     string   `short:"p" long:"prepare-script" description:"Script to run to prepare a run"`
+	PrepareScriptArgs []string `long:"prepare-script-args" description:"Args to provide to the prepare script"`
+	RestoreScript     string   `short:"r" long:"restore-script" description:"Script to run to restore after a run"`
+	RestoreScriptArgs []string `long:"restore-script-args" description:"Args to provide to the restore script"`
+	KeepVMCaches      bool     `short:"v" long:"keep-vm-caches" description:"Don't free VM caches before executing"`
+	WindowClass       string   `short:"c" long:"class-name" description:"Window class to use with xdotool instead of the the first Command"`
+	WindowClassName   string   `long:"window-class-name" description:"Window class name to use with xdotool"`
 	RunThroughSnap    bool     `short:"s" long:"use-snap-run" description:"Run command through snap run"`
+	RunThroughFlatpak bool     `short:"f" long:"use-flatpak-run" description:"Run command through flatpak run"`
 	DiscardSnapNs     bool     `short:"d" long:"discard-snap-ns" description:"Discard the snap namespace before running the snap"`
 	ProgramStdoutLog  string   `long:"cmd-stdout" description:"Log file for run command's stdout"`
 	ProgramStderrLog  string   `long:"cmd-stderr" description:"Log file for run command's stderr"`

--- a/internal/xdotool/xdotool.go
+++ b/internal/xdotool/xdotool.go
@@ -31,8 +31,9 @@ type xdotool struct{}
 
 // Window represents a X11 window
 type Window struct {
-	Class string
-	Name  string
+	Class     string
+	ClassName string
+	Name      string
 }
 
 func (w Window) windowSpecErrDescription() string {
@@ -40,6 +41,8 @@ func (w Window) windowSpecErrDescription() string {
 		return fmt.Sprintf("class %s", w.Class)
 	} else if w.Name != "" {
 		return fmt.Sprintf("name %s", w.Name)
+	} else if w.ClassName != "" {
+		return fmt.Sprintf("class name %s", w.ClassName)
 	} else {
 		return "no specification"
 	}
@@ -50,6 +53,8 @@ func (w Window) searchArgs() []string {
 		return []string{"--class", w.Class}
 	} else if w.Name != "" {
 		return []string{"--name", w.Name}
+	} else if w.ClassName != "" {
+		return []string{"--classname", w.ClassName}
 	}
 	return nil
 }


### PR DESCRIPTION
Needs to be researched a bit for the file command, but it works well for the
exec command using the automatic classname option with xdotool.

Also add a corresponding option for --classname.

Example output with a flatpak:

```
$ ./etrace exec --use-flatpak-run --no-trace org.gabmus.whatip
Total startup time: 1.596067141s
Gdk-Message: 17:49:30.377: org.gabmus.whatip: Fatal IO error 0 (Success) on X server :99.0.
```

It still needs some love when it comes to tracing, as it just outputs /bin/sh for some reason right now:

```
$ ./etrace exec -f org.gabmus.whatip

Gdk-Message: 17:49:08.685: org.gabmus.whatip: Fatal IO error 0 (Success) on X server :99.0.

1 exec calls during snap run:
     Start  Stop   Elapsed      Exec
     0      19078  19.078016ms  /bin/sh
Total time:  2.246505976s
Total startup time: 2.233035943s
```

Updates #25 