### PR TITLE
cmd/etrace/exec: always output in seconds

### DIFF
--- a/cmd/etrace/cmd_exec.go
+++ b/cmd/etrace/cmd_exec.go
@@ -563,7 +563,7 @@ func (x *cmdExec) Execute(args []string) error {
 		outRes.Runs = append(outRes.Runs, run)
 
 		if !currentCmd.JSONOutput {
-			fmt.Fprintln(w, "Total startup time:", startup)
+			fmt.Fprintln(w, "Total startup time:", startup.Seconds())
 		}
 
 		resetErrors()


### PR DESCRIPTION
Fixes: https://github.com/canonical/etrace/issues/43