### PR TITLE
cmd/etrace/exec: don't automatically set no-trace with --hold|--cold

### DIFF
--- a/cmd/etrace/cmd_exec.go
+++ b/cmd/etrace/cmd_exec.go
@@ -87,7 +87,6 @@ func (x *cmdExec) Execute(args []string) error {
 
 	// handle meta options which override other options
 	if x.ColdWorstCase {
-		x.NoTrace = true
 		x.CleanSnapUserData = true
 		x.ReinstallSnap = true
 
@@ -95,7 +94,6 @@ func (x *cmdExec) Execute(args []string) error {
 		currentCmd.KeepVMCaches = false
 		currentCmd.DiscardSnapNs = true
 	} else if x.HotBestCase {
-		x.NoTrace = true
 		x.CleanSnapUserData = false
 		x.ReinstallSnap = false
 


### PR DESCRIPTION
It is also useful to be able to use --hot or --cold with tracing to see where
some slowdowns happen in these cases, and with this it isn't possible to use
the easy options as the easy options were forcing no-trace to be true always.