### PR TITLE
cmd/etrace: add analyze-snap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@
 
 _etrace_ is a utility like strace or ltrace which uses ptrace to follow programs executed by a main program for performance and debugging analysis. It also supports limited tracing of file accesses for analyzing what files a program accesses during it's execution.
 
+## Basics
+
+Simple, quick (relatively speaking) and dirty way to get numbers on how fast/slow a graphical snap like [`gnome-calculator`](https://snapcraft.io/gnome-calculator) is:
+
+Worst case performance (like when you first turn on and log into your machine):
+
+```bash
+$ etrace exec -t --silent --cold gnome-calculator
+Total startup time: 4.169633359
+```
+
+Best case performance (after everything is cached and ready to go):
+
+```bash
+$ etrace exec -t --silent --hot gnome-calculator > /dev/null # to warm up all caches
+$ etrace exec -t --silent --hot gnome-calculator # actual measurement
+Total startup time: 1.054272336
+```
+
 ## Installation
 
 The easiest way to get etrace is via a snap:
@@ -26,7 +45,7 @@ $ cd etrace && go install ./...
 
 ## Usage
 
-_etrace_ has two subcommands, `exec` and `file`.
+_etrace_ has three subcommands, `exec`, `file`, and `analyze-snap`.
 
 ### `exec` subcommand
 
@@ -52,6 +71,7 @@ Application Options:
   -f, --use-flatpak-run           Run command through flatpak run
   -d, --discard-snap-ns           Discard the snap namespace before running the snap
       --cmd-stdout=               Log file for run command's stdout
+      --silent                    Silence all program output
       --cmd-stderr=               Log file for run command's stderr
   -j, --json                      Output results in JSON
   -o, --output-file=              A file to output the results (empty string means stdout)
@@ -97,6 +117,7 @@ Application Options:
   -f, --use-flatpak-run             Run command through flatpak run
   -d, --discard-snap-ns             Discard the snap namespace before running the snap
       --cmd-stdout=                 Log file for run command's stdout
+      --silent                      Silence all program output
       --cmd-stderr=                 Log file for run command's stderr
   -j, --json                        Output results in JSON
   -o, --output-file=                A file to output the results (empty string means stdout)
@@ -115,6 +136,53 @@ Help Options:
 
 [file command arguments]
   Cmd:                              Command to run
+```
+
+### `analyze-snap` subcommand
+
+The `analyze-snap` subcommand will run a few different tests of the specified snap, mainly heuristics around guesses of what might be relevant to why a graphical snap is performing poorly. It takes a snap name, and will install that snap from the store (with an optional channel specification) if it is not already installed. It will make a backup of all the snap user data for that snap before executing tests, but this is not 100% foolproof, so it is suggested that you manually backup any sensitive data for the snap. The snap will also be removed and reinstalled multiple times, but any revisions of the snap that are inactive (i.e. old revisions) that exist at the time of running the command will be lost due to garbage collection by snapd when removing and reinstalling the snap.
+
+Right now, the main assumption it makes is that most snaps that are XZ are slow, and that they would benefit from switching to LZO, so if the specified snap is using XZ, it will analyze the results of switching to XZ. Eventually, it would be great to extend it to do other sorts of performance/execution related analysis. If the snap is already LZO, then it skips the comparison and just displays the cold/hot statistics.
+
+The subcomand currently doesn't obey all of the global options that etrace uses, but that should be fixed up soon.
+
+Finally, note that since it executes the specified snap 40 times, with 20 of those executions "slow" worst case performance scenarios, it can take a decent chunk of time to finish, but just give it time and it will spit out results. A progress bar would be a great addition that I haven't added yet.
+
+_etrace analyze-snap_ usage:
+
+```
+Usage:
+  etrace [OPTIONS] analyze-snap [analyze-snap-OPTIONS] Snap
+
+Application Options:
+  -e, --errors               Show errors as they happen
+  -w, --window-name=         Window name to wait for
+  -p, --prepare-script=      Script to run to prepare a run
+      --prepare-script-args= Args to provide to the prepare script
+  -r, --restore-script=      Script to run to restore after a run
+      --restore-script-args= Args to provide to the restore script
+  -v, --keep-vm-caches       Don't free VM caches before executing
+  -c, --class-name=          Window class to use with xdotool instead of the the first Command
+      --window-class-name=   Window class name to use with xdotool
+  -s, --use-snap-run         Run command through snap run
+  -f, --use-flatpak-run      Run command through flatpak run
+  -d, --discard-snap-ns      Discard the snap namespace before running the snap
+      --cmd-stdout=          Log file for run command's stdout
+      --silent               Silence all program output
+      --cmd-stderr=          Log file for run command's stderr
+  -j, --json                 Output results in JSON
+  -o, --output-file=         A file to output the results (empty string means stdout)
+      --no-window-wait       Don't wait for the window to appear, just run until the program exits
+      --window-timeout=      Global timeout for waiting for windows to appear. Set to empty string to use no timeout (default: 60s)
+
+Help Options:
+  -h, --help                 Show this help message
+
+[analyze-snap command options]
+          --channel=         Channel to install the snap from if not already installed
+
+[analyze-snap command arguments]
+  Snap:                      Snap to analyze
 ```
 
 
@@ -187,13 +255,42 @@ $ ./etrace file --no-window-wait --cmd-stderr=/dev/null jq
 Total startup time: 125.04791ms
 ```
 
+Analyzing a snap (note that this example took about 15 minutes to execute on a decently powerful Ubuntu desktop):
+
+```
+$ etrace analyze-snap 1password
+original snap size: 82.45 MiB
+original compression format is xz
+content snap slot dependencies: [gnome-3-28-1804 gtk-common-themes]
+worst case performance:
+        average time to display: 14.021772885s
+        standard deviation for time to display: 598.600444ms
+best case performance:
+        average time to display: 1.096632064s
+        standard deviation for time to display: 45.572462ms
+worst case performance with LZO compression:
+        average time to display: 4.692383384s
+        standard deviation for time to display: 51.066194ms
+        average time to display percent change: -66.54%
+best case performance with LZO compression:
+        average time to display: 1.110948092s
+        standard deviation for time to display: 19.30841ms
+        average time to display percent change: +1.31%
+lzo snap size: 105.62 MiB (change of +28.10%)
+```
+
 ## Current Limitations
 
 Currently, the `file` subcommand has a few limitations. 
 
 1. We currently only measure files that are under $SNAP, ideally this should be controllable by regex specified with an option
 1. Due to 1, we only support measuring files accessed by snap apps, but this limitation should go away when we can specify what files to measure with an option.
-1. The `--repeat` option is not yet implemented.
+
+The `analyze-snap` subcommand has the following limitations:
+
+1. None of the global options that are shared with `exec` and `file` are not yet understood/passed along.
+1. The output for `analyze-snap` isn't stable and will probably be adjusted
+1. The `analyze-snap` command can take a long time but doesn't convey at all how far along it is in the execution.
 
 ## License
 This project is licensed under the GPLv3. See LICENSE file for full license. Copyright 2019-2021 Canonical Ltd.

--- a/cmd/etrace/cmd_analyze_snap.go
+++ b/cmd/etrace/cmd_analyze_snap.go
@@ -1,0 +1,338 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/anonymouse64/etrace/internal/commands"
+	"github.com/anonymouse64/etrace/internal/snaps"
+
+	// TODO: eliminate this dependency
+	"github.com/snapcore/snapd/gadget/quantity"
+)
+
+type cmdAnalyzeSnap struct {
+	InstallChannel string `long:"channel" description:"Channel to install the snap from if not already installed"`
+	Args           struct {
+		Snap string `description:"Snap to analyze" required:"yes"`
+	} `positional-args:"yes" required:"yes"`
+}
+
+func (x *cmdAnalyzeSnap) Execute(args []string) error {
+
+	snapName := x.Args.Snap
+
+	// analyze looks at a few aspects of the snap:
+	// 1. The size of the snap as-is from installed
+	// 2. What compression format the snap is using
+	// 3. What content interface dependency snaps does this snap have
+	// 4. Worst case performance launch data
+	// 5. Best case performance launch data
+	// 6. (optional) if XZ compressed, worst case performance launch if it was switched to LZO
+	// 7. (optional) if XZ compressed, best case performance launch if it was switched to LZO
+	// 8. (optional) if XZ compressed, file size increase if it was switched to LZO
+
+	tmpWorkDir, err := ioutil.TempDir("", fmt.Sprintf("etrace-analyze-%s", snapName))
+	if err != nil {
+		return err
+	}
+
+	// first ensure the snap is installed, if it is not then download it
+	if !snaps.IsInstalled(snapName) {
+		// then install it
+		if err := exec.Command("snap", "install", snapName, "--channel="+x.InstallChannel).Run(); err != nil {
+			return fmt.Errorf("unable to install snap %s and analyze: %w", snapName, err)
+		}
+
+	}
+
+	// now make a copy of what is currently installed as the original version to
+	// analyze and compare with possibly alternative compression formats
+	rev, err := snaps.Revision(snapName)
+	if err != nil {
+		return err
+	}
+
+	originalSnapFile := filepath.Join(tmpWorkDir, snapName+".snap")
+	// TODO: need to use cp manually here
+	cpCmd := exec.Command("cp", filepath.Join("/var/lib/snapd/snaps/", snapName+"_"+rev+".snap"), originalSnapFile)
+	commands.AddSudoIfNeeded(cpCmd)
+	if err := cpCmd.Run(); err != nil {
+		return err
+	}
+
+	// 1. get the original size
+	st, err := os.Stat(originalSnapFile)
+	if err != nil {
+		// very unexpected as we just copied the file
+		return err
+	}
+	origSz := quantity.Size(st.Size())
+	fmt.Printf("original snap size: %s\n", origSz.IECString())
+
+	// 2. get what compression format this snap is using
+	unsquashfsCmd := exec.Command("unsquashfs", "-s", originalSnapFile)
+	if err := commands.AddSudoIfNeeded(unsquashfsCmd); err != nil {
+		return err
+	}
+
+	unsquashfsOut, err := unsquashfsCmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+
+	// look for the compression format line
+	s := bufio.NewScanner(bytes.NewReader(unsquashfsOut))
+	compressionLineRegexp := regexp.MustCompile(`^Compression ([a-zA-Z0-9]+)$`)
+	compressionFormat := ""
+	for s.Scan() {
+		line := s.Text()
+		matches := compressionLineRegexp.FindStringSubmatch(line)
+		if len(matches) == 0 {
+			continue
+		}
+		compressionFormat = matches[1]
+		break
+	}
+
+	if compressionFormat == "" {
+		// TODO: what about test snaps with actually no compression in the squashfs?
+		return fmt.Errorf("error: snap has no compression or unsquashfs output is corrupted")
+	}
+
+	fmt.Printf("original compression format is %s\n", compressionFormat)
+
+	// 3. get what content interface dependency snaps this snap has by looking
+	// at the slots for all connections, excluding system snap provided slots
+	// and slots this snap provides
+	conns, err := snaps.CurrentConnections(snapName)
+	if err != nil {
+		return err
+	}
+	contentInterfaceDependencySnapsMap := map[string]bool{}
+	for _, conn := range conns {
+		switch conn.SlotSnap {
+		case "system", snapName:
+			continue
+		default:
+			contentInterfaceDependencySnapsMap[conn.SlotSnap] = true
+		}
+	}
+
+	contentInterfaceDependencySnaps := make([]string, 0, len(contentInterfaceDependencySnapsMap))
+	for snap := range contentInterfaceDependencySnapsMap {
+		contentInterfaceDependencySnaps = append(contentInterfaceDependencySnaps, snap)
+	}
+
+	fmt.Printf("content snap slot dependencies: %+v\n", contentInterfaceDependencySnaps)
+
+	// 4. Get the worst case performance data using etrace
+	meanWorst, stdDevWorst, err := performanceData("--cold", snapName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("worst case performance:\n")
+	fmt.Printf("\taverage time to display: %s\n", meanWorst)
+	fmt.Printf("\tstandard deviation for time to display: %s\n", stdDevWorst)
+
+	// 5. Get the best case performance data using etrace
+	meanBest, stdDevBest, err := performanceData("--hot", snapName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("best case performance:\n")
+	fmt.Printf("\taverage time to display: %s\n", meanBest)
+	fmt.Printf("\tstandard deviation for time to display: %s\n", stdDevBest)
+
+	if strings.ToLower(compressionFormat) != "xz" {
+		// nothing left to check
+		return nil
+	}
+
+	// otherwise it was xz, we should check LZO
+
+	// first unpack the snap and repack it with LZO
+	lzoSnapFile := filepath.Join(tmpWorkDir, snapName+"_lzo.snap")
+	unpackDir := filepath.Join(tmpWorkDir, "unpacked-snap")
+	unsquashfsCmd = exec.Command("unsquashfs", "-d", unpackDir, originalSnapFile)
+	commands.AddSudoIfNeeded(unsquashfsCmd)
+	if err := unsquashfsCmd.Run(); err != nil {
+		return err
+	}
+
+	// now re-pack as lzo
+	packCmd := exec.Command("snap",
+		"pack",
+		"--filename="+lzoSnapFile,
+		"--compression=lzo",
+		unpackDir,
+	)
+	commands.AddSudoIfNeeded(packCmd)
+	if err := packCmd.Run(); err != nil {
+		return err
+	}
+
+	// now install the lzo version
+	// TODO: handle devmode or classic snap options, etc. with the logic from
+	// exec cmd
+	installCmd := exec.Command("snap", "install", "--dangerous", lzoSnapFile)
+	commands.AddSudoIfNeeded(installCmd)
+	if err := installCmd.Run(); err != nil {
+		return err
+	}
+
+	// defer a revert command to the original revision we had installed
+	defer func() {
+		revertCmd := exec.Command("snap", "install", originalSnapFile)
+		commands.AddSudoIfNeeded(revertCmd)
+		if err := revertCmd.Run(); err != nil {
+			fmt.Printf("error reverting to previous version of %s\n: %v", snapName, err)
+		}
+	}()
+
+	// now we should have the LZO version installed, get data for this one
+
+	// 6. Get the worst case performance data using etrace
+	meanWorstLZO, stdDevWorseLZO, err := performanceData("--cold", snapName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("worst case performance with LZO compression:\n")
+	fmt.Printf("\taverage time to display: %s\n", meanWorstLZO)
+	fmt.Printf("\tstandard deviation for time to display: %s\n", stdDevWorseLZO)
+	fmt.Printf("\taverage time to display percent change: %s\n", percentDiffDuration(meanWorst, meanWorstLZO))
+
+	// 7. Get the best case performance data using etrace
+	meanBestLZO, stdDevBestLZO, err := performanceData("--hot", snapName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("best case performance with LZO compression:\n")
+	fmt.Printf("\taverage time to display: %s\n", meanBestLZO)
+	fmt.Printf("\tstandard deviation for time to display: %s\n", stdDevBestLZO)
+	fmt.Printf("\taverage time to display percent change: %s\n", percentDiffDuration(meanBest, meanBestLZO))
+
+	// 8. Calculate the percent change in filesize between LZO and XZ
+	st, err = os.Stat(lzoSnapFile)
+	if err != nil {
+		return err
+	}
+	lzoSz := quantity.Size(st.Size())
+	fmt.Printf("lzo snap size: %s (change of %s)\n", lzoSz.IECString(), percentDiffSz(origSz, lzoSz))
+
+	return nil
+}
+
+func percentDiffDuration(d1, d2 time.Duration) string {
+	sign := ""
+	if d1 < d2 {
+		sign = "+"
+	} else {
+		sign = "-"
+	}
+	return fmt.Sprintf("%s%.2f%%", sign, math.Abs(100*float64(d2-d1)/float64(d1)))
+}
+
+func percentDiffSz(sz1, sz2 quantity.Size) string {
+	sign := ""
+	if sz1 < sz2 {
+		sign = "+"
+	} else {
+		sign = "-"
+	}
+	return fmt.Sprintf("%s%.2f%%", sign, math.Abs(100*float64(sz2-sz1)/float64(sz1)))
+}
+
+func meanAndStdDevForRuns(runs ExecOutputResult) (time.Duration, time.Duration, error) {
+	// analyze the TimeToDisplay field for all the runs
+	count := float64(len(runs.Runs))
+	var mean float64
+	for _, run := range runs.Runs {
+		if run.TimeToDisplay == 0 {
+			// this is unexpected
+			return 0, 0, fmt.Errorf("error: run produced time of exactly 0")
+		}
+
+		mean += float64(run.TimeToDisplay)
+	}
+	mean = mean / count
+
+	sumDiffSq := float64(0)
+	for _, run := range runs.Runs {
+		diff := float64(run.TimeToDisplay) - mean
+		sumDiffSq += (diff * diff)
+	}
+	stdDev := time.Duration(math.Sqrt(sumDiffSq / count))
+
+	return time.Duration(mean), stdDev, nil
+}
+
+func performanceData(mode, snapName string) (man, stdDev time.Duration, err error) {
+	runs := "10"
+	if mode == "--hot" {
+		runs = "11"
+	}
+
+	// TODO: just call the right functions from this same process, this is a bit
+	// unfortunate to call ourself externally like this
+	cmd := exec.Command("etrace",
+		"exec",
+		"--json",                 // we want machine readable output
+		"--repeat="+runs,         // we want statistically significant results
+		"--use-snap-run",         // we are running a snap
+		mode,                     // for whatever mode was specified
+		"--cmd-stderr=/dev/null", // we don't want any stderr output
+		"--cmd-stdout=/dev/null", // we don't want any stdout output
+		"--no-trace",             // we don't want to trace for best performance
+		snapName,
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// parse the output as json
+	var execOutputJSON ExecOutputResult
+	if err := json.Unmarshal(out, &execOutputJSON); err != nil {
+		return 0, 0, err
+	}
+
+	if mode == "--hot" {
+		// discard the first run as it may have been a "cold" one
+		execOutputJSON.Runs = execOutputJSON.Runs[1:]
+	}
+
+	return meanAndStdDevForRuns(execOutputJSON)
+}

--- a/cmd/etrace/cmd_analyze_snap_test.go
+++ b/cmd/etrace/cmd_analyze_snap_test.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"testing"
+	"time"
+
+	main "github.com/anonymouse64/etrace/cmd/etrace"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type analyzeSnapTestSuite struct{}
+
+var _ = Suite(&analyzeSnapTestSuite{})
+
+func (p *analyzeSnapTestSuite) TestMeanAndStdDevForRuns(c *C) {
+	tt := []struct {
+		vals      []int64
+		expMean   int64
+		expStdDev int64
+		expErr    string
+	}{
+		{
+			vals: []int64{
+				10000,
+				20000,
+				30000,
+				40000,
+				50000,
+			},
+			expMean:   30000,
+			expStdDev: 14142,
+		},
+	}
+
+	for _, t := range tt {
+		exec := main.ExecOutputResult{}
+		exec.Runs = make([]main.Execution, len(t.vals))
+		for i, val := range t.vals {
+			exec.Runs[i].TimeToDisplay = time.Duration(val)
+		}
+
+		mean, stdDev, err := main.MeanAndStdDevForRuns(exec)
+		if t.expErr != "" {
+			c.Check(err, ErrorMatches, t.expErr)
+			continue
+		}
+		c.Assert(mean, Equals, time.Duration(t.expMean))
+		c.Assert(stdDev, Equals, time.Duration(t.expStdDev))
+	}
+
+}

--- a/cmd/etrace/cmd_exec.go
+++ b/cmd/etrace/cmd_exec.go
@@ -139,11 +139,8 @@ func (x *cmdExec) Execute(args []string) error {
 	snapName := x.Args.Cmd[0]
 
 	// check if the snap is installed first if --use-snap-run is specified
-	if currentCmd.RunThroughSnap {
-		if _, err := exec.Command("snap", "list", snapName).CombinedOutput(); err != nil {
-			// then the snap is assumed to not be installed
-			return fmt.Errorf("snap %s is not installed", snapName)
-		}
+	if currentCmd.RunThroughSnap && !snaps.IsInstalled(snapName) {
+		return fmt.Errorf("snap %s is not installed", snapName)
 	}
 
 	if x.CleanSnapUserData {
@@ -290,6 +287,9 @@ func (x *cmdExec) Execute(args []string) error {
 			if err != nil {
 				return fmt.Errorf("failed to remove snap %s: %v (%s)", snapName, err, string(removeOut))
 			}
+
+			// TODO: defer something to go back to the original state of the
+			// snap here if we get interrupted
 
 			// now reinstall the snap
 			installCmd := exec.Command("snap", "install", tmpSnap)

--- a/cmd/etrace/export_test.go
+++ b/cmd/etrace/export_test.go
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package main
+
+var (
+	MeanAndStdDevForRuns = meanAndStdDevForRuns
+)

--- a/cmd/etrace/main.go
+++ b/cmd/etrace/main.go
@@ -33,27 +33,28 @@ import (
 
 // Command is the command for the runner
 type Command struct {
-	File                    cmdFile  `command:"file" description:"Trace files accessed from a program"`
-	Exec                    cmdExec  `command:"exec" description:"Trace the program executions from a program"`
-	ShowErrors              bool     `short:"e" long:"errors" description:"Show errors as they happen"`
-	WindowName              string   `short:"w" long:"window-name" description:"Window name to wait for"`
-	PrepareScript           string   `short:"p" long:"prepare-script" description:"Script to run to prepare a run"`
-	PrepareScriptArgs       []string `long:"prepare-script-args" description:"Args to provide to the prepare script"`
-	RestoreScript           string   `short:"r" long:"restore-script" description:"Script to run to restore after a run"`
-	RestoreScriptArgs       []string `long:"restore-script-args" description:"Args to provide to the restore script"`
-	KeepVMCaches            bool     `short:"v" long:"keep-vm-caches" description:"Don't free VM caches before executing"`
-	WindowClass             string   `short:"c" long:"class-name" description:"Window class to use with xdotool instead of the the first Command"`
-	WindowClassName         string   `long:"window-class-name" description:"Window class name to use with xdotool"`
-	RunThroughSnap          bool     `short:"s" long:"use-snap-run" description:"Run command through snap run"`
-	RunThroughFlatpak       bool     `short:"f" long:"use-flatpak-run" description:"Run command through flatpak run"`
-	DiscardSnapNs           bool     `short:"d" long:"discard-snap-ns" description:"Discard the snap namespace before running the snap"`
-	ProgramStdoutLog        string   `long:"cmd-stdout" description:"Log file for run command's stdout"`
-	ProgramStderrLog        string   `long:"cmd-stderr" description:"Log file for run command's stderr"`
-	SilentProgram           bool     `long:"silent" description:"Silence all program output"`
-	JSONOutput              bool     `short:"j" long:"json" description:"Output results in JSON"`
-	OutputFile              string   `short:"o" long:"output-file" description:"A file to output the results (empty string means stdout)"`
-	NoWindowWait            bool     `long:"no-window-wait" description:"Don't wait for the window to appear, just run until the program exits"`
-	WindowWaitGlobalTimeout string   `long:"window-timeout" default:"60s" description:"Global timeout for waiting for windows to appear. Set to empty string to use no timeout"`
+	File                    cmdFile        `command:"file" description:"Trace files accessed from a program"`
+	Exec                    cmdExec        `command:"exec" description:"Trace the program executions from a program"`
+	AnalyzeSnap             cmdAnalyzeSnap `command:"analyze-snap" description:"Analyze a snap for performance data"`
+	ShowErrors              bool           `short:"e" long:"errors" description:"Show errors as they happen"`
+	WindowName              string         `short:"w" long:"window-name" description:"Window name to wait for"`
+	PrepareScript           string         `short:"p" long:"prepare-script" description:"Script to run to prepare a run"`
+	PrepareScriptArgs       []string       `long:"prepare-script-args" description:"Args to provide to the prepare script"`
+	RestoreScript           string         `short:"r" long:"restore-script" description:"Script to run to restore after a run"`
+	RestoreScriptArgs       []string       `long:"restore-script-args" description:"Args to provide to the restore script"`
+	KeepVMCaches            bool           `short:"v" long:"keep-vm-caches" description:"Don't free VM caches before executing"`
+	WindowClass             string         `short:"c" long:"class-name" description:"Window class to use with xdotool instead of the the first Command"`
+	WindowClassName         string         `long:"window-class-name" description:"Window class name to use with xdotool"`
+	RunThroughSnap          bool           `short:"s" long:"use-snap-run" description:"Run command through snap run"`
+	RunThroughFlatpak       bool           `short:"f" long:"use-flatpak-run" description:"Run command through flatpak run"`
+	DiscardSnapNs           bool           `short:"d" long:"discard-snap-ns" description:"Discard the snap namespace before running the snap"`
+	ProgramStdoutLog        string         `long:"cmd-stdout" description:"Log file for run command's stdout"`
+	ProgramStderrLog        string         `long:"cmd-stderr" description:"Log file for run command's stderr"`
+	SilentProgram           bool           `long:"silent" description:"Silence all program output"`
+	JSONOutput              bool           `short:"j" long:"json" description:"Output results in JSON"`
+	OutputFile              string         `short:"o" long:"output-file" description:"A file to output the results (empty string means stdout)"`
+	NoWindowWait            bool           `long:"no-window-wait" description:"Don't wait for the window to appear, just run until the program exits"`
+	WindowWaitGlobalTimeout string         `long:"window-timeout" default:"60s" description:"Global timeout for waiting for windows to appear. Set to empty string to use no timeout"`
 }
 
 // The current input command

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.13
 require (
 	github.com/jessevdk/go-flags v1.4.1-0.20180927143258-7309ec74f752
 	github.com/kr/pretty v0.1.0 // indirect
+	github.com/snapcore/snapd v0.0.0-20210726143858-26a7ab7b6a92
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/snapcore/snapd v0.0.0-20210726143858-26a7ab7b6a92 h1:hHdjkWn9NiFwEYQel1BYvHH5mAWONATktZEU1WmmAE0=
+github.com/snapcore/snapd v0.0.0-20210726143858-26a7ab7b6a92/go.mod h1:3xrn7QDDKymcE5VO2rgWEQ5ZAUGb9htfwlXnoel6Io8=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -12,5 +14,8 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/internal/snaps/snaps.go
+++ b/internal/snaps/snaps.go
@@ -144,3 +144,11 @@ func CurrentConnections(snapName string) ([]Connection, error) {
 
 	return conns, nil
 }
+
+func IsInstalled(snapName string) bool {
+	if _, err := exec.Command("snap", "list", snapName).CombinedOutput(); err != nil {
+		// then the snap is assumed to not be installed
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Add an analyze-snap subcommand which can be used to easily analyze performance data about a specific snap.

Also update the README and examples there