### PR TITLE
cmd/etrace/analyze-snap: support --compression option to choose what to compare

### DIFF
--- a/cmd/etrace/cmd_analyze_snap.go
+++ b/cmd/etrace/cmd_analyze_snap.go
@@ -318,7 +318,9 @@ func percentDiffDuration(d1, d2 time.Duration) string {
 	} else {
 		sign = "-"
 	}
-	return fmt.Sprintf("%s%.2f%%", sign, math.Abs(100*float64(d2-d1)/float64(d1)))
+	d1Float := float64(d1)
+	d2Float := float64(d2)
+	return fmt.Sprintf("%s%.2f%%", sign, math.Abs(100*(d2Float-d1Float)/d1Float))
 }
 
 func percentDiffSz(sz1, sz2 quantity.Size) string {
@@ -328,7 +330,9 @@ func percentDiffSz(sz1, sz2 quantity.Size) string {
 	} else {
 		sign = "-"
 	}
-	return fmt.Sprintf("%s%.2f%%", sign, math.Abs(100*float64(sz2-sz1)/float64(sz1)))
+	sz1Float := float64(sz1)
+	sz2Float := float64(sz2)
+	return fmt.Sprintf("%s%.2f%%", sign, math.Abs(100*(sz2Float-sz1Float)/sz1Float))
 }
 
 func meanAndStdDevForRuns(runs ExecOutputResult) (time.Duration, time.Duration, error) {


### PR DESCRIPTION
This allows one to continue by default comparing XZ snaps with LZO, but also to
compare i.e. none, gzip, zstd, etc. against whatever the default compression
ends up being.

Also fix a math bug which resulted in comparing sz1 as 141.93 MiB and sz2 being 121.88 MiB having a percent difference change of `-12394659769823.48%` which I'm fairly certain is wrong.