### PR TITLE
cmd/etrace/analyze-snap: better error reporting

### DIFF
--- a/cmd/etrace/cmd_analyze_snap.go
+++ b/cmd/etrace/cmd_analyze_snap.go
@@ -387,7 +387,7 @@ func performanceData(mode, snapName string) (man, stdDev time.Duration, err erro
 	// parse the output as json
 	var execOutputJSON ExecOutputResult
 	if err := json.Unmarshal(out, &execOutputJSON); err != nil {
-		return 0, 0, err
+		return 0, 0, fmt.Errorf("error getting results from sub-etrace process: %v (full output is %s)", err, string(out))
 	}
 
 	if mode == "--hot" {


### PR DESCRIPTION
Before this would not show us the real error:

json: cannot unmarshal object into Go struct field Execution.Runs.Errors of type error

which is not helpful in actually debugging.