### PR TITLE
cmd/etrace: fix error serialization in JSON

### DIFF
--- a/cmd/etrace/cmd_analyze_snap.go
+++ b/cmd/etrace/cmd_analyze_snap.go
@@ -72,7 +72,6 @@ func (x *cmdAnalyzeSnap) Execute(args []string) error {
 		if err := exec.Command("snap", "install", snapName, "--channel="+x.InstallChannel).Run(); err != nil {
 			return fmt.Errorf("unable to install snap %s and analyze: %w", snapName, err)
 		}
-
 	}
 
 	// now make a copy of what is currently installed as the original version to
@@ -389,6 +388,8 @@ func performanceData(mode, snapName string) (man, stdDev time.Duration, err erro
 	if err := json.Unmarshal(out, &execOutputJSON); err != nil {
 		return 0, 0, fmt.Errorf("error getting results from sub-etrace process: %v (full output is %s)", err, string(out))
 	}
+
+	// TODO: actually handle errors in the result here
 
 	if mode == "--hot" {
 		// discard the first run as it may have been a "cold" one

--- a/cmd/etrace/cmd_exec.go
+++ b/cmd/etrace/cmd_exec.go
@@ -54,7 +54,7 @@ type Execution struct {
 	ExecveTiming  *strace.ExecveTiming `json:",omitempty"`
 	TimeToDisplay time.Duration        `json:",omitempty"`
 	TimeToRun     time.Duration        `json:",omitempty"`
-	Errors        []error              `json:",omitempty"`
+	Errors        []string             `json:",omitempty"`
 }
 
 type cmdExec struct {

--- a/cmd/etrace/cmd_file.go
+++ b/cmd/etrace/cmd_file.go
@@ -55,7 +55,7 @@ type cmdFile struct {
 type FileOutputResult struct {
 	ExecvePaths   *strace.ExecvePaths `json:",omitempty"`
 	TimeToDisplay time.Duration       `json:",omitempty"`
-	Errors        []error             `json:",omitempty"`
+	Errors        []string            `json:",omitempty"`
 }
 
 func (x *cmdFile) Execute(args []string) error {

--- a/cmd/etrace/main.go
+++ b/cmd/etrace/main.go
@@ -131,14 +131,14 @@ func tabWriterGeneric(w io.Writer) *tabwriter.Writer {
 	return tabwriter.NewWriter(w, 5, 3, 2, ' ', 0)
 }
 
-var errs []error
+var errs []string
 
 func resetErrors() {
 	errs = nil
 }
 
 func logError(err error) {
-	errs = append(errs, err)
+	errs = append(errs, err.Error())
 	if currentCmd.ShowErrors {
 		log.Println(err)
 	}

--- a/internal/strace/display-opts.go
+++ b/internal/strace/display-opts.go
@@ -19,7 +19,7 @@ package strace
 
 // DisplayOptions is a silly struct for passing in display options like whether
 // to display programs or just files for the file command
-// TOOD: make this go away and do it more cleanly
+// TODO: make this go away and do it more cleanly
 type DisplayOptions struct {
 	NoDisplayPrograms bool
 }


### PR DESCRIPTION
Errors were being serialized as "{}" since the error type is technically
treated as a struct, but with no exported fields. Instead the type we want to
use to serialize errors is a string, which allows saving the error message.

Still to do is to handle errors from the sub-process etrace that is called in
analyze-snap, but for now as long as there is a valid number for each of the
measurements we still treat it as valid.

Also fix a typo.

Thanks to @popey for finding this bug with the vlc snap and for helping me 
identify/debug it.