### PR TITLE
cmd/etrace/analyze-snap: pass window related opts from analyze-snap to sub-proc

### DIFF
--- a/cmd/etrace/cmd_analyze_snap.go
+++ b/cmd/etrace/cmd_analyze_snap.go
@@ -366,17 +366,29 @@ func performanceData(mode, snapName string) (man, stdDev time.Duration, err erro
 
 	// TODO: just call the right functions from this same process, this is a bit
 	// unfortunate to call ourself externally like this
-	cmd := exec.Command("etrace",
-		"exec",
+	args := []string{"exec",
 		"--json",                 // we want machine readable output
-		"--repeat="+runs,         // we want statistically significant results
+		"--repeat=" + runs,       // we want statistically significant results
 		"--use-snap-run",         // we are running a snap
 		mode,                     // for whatever mode was specified
 		"--cmd-stderr=/dev/null", // we don't want any stderr output
 		"--cmd-stdout=/dev/null", // we don't want any stdout output
 		"--no-trace",             // we don't want to trace for best performance
 		snapName,
-	)
+	}
+
+	// handle window opts passed into analyze-snap
+	if currentCmd.WindowName != "" {
+		args = append(args, "--window-name="+currentCmd.WindowName)
+	}
+	if currentCmd.WindowClass != "" {
+		args = append(args, "--class-name="+currentCmd.WindowClass)
+	}
+	if currentCmd.WindowClassName != "" {
+		args = append(args, "--window-class-name="+currentCmd.WindowClassName)
+	}
+
+	cmd := exec.Command("etrace", args...)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
This is for snaps like antstream-arcade which don't have a class name that is
the same as their snap name, here we need a window name of "Antstream Arcade"
like in

etrace analyze-snap antstream-arcade --window-class-name="Antstream Arcade"

cc @popey who originally reported this.

Related: https://github.com/canonical/etrace/issues/66

On my machine with this branch:

```
$ etrace analyze-snap --window-class-name="Antstream Arcade" antstream-arcade
original snap size: 280.74 MiB
original compression format is xz
content snap slot dependencies: []
worst case performance:
	average time to display: 7.441698675s
	standard deviation for time to display: 525.311926ms
best case performance:
	average time to display: 880.465886ms
	standard deviation for time to display: 212.061921ms
worst case performance with lzo compression:
	average time to display: 3.446305791s
	standard deviation for time to display: 1.040510841s
	average time to display percent change: -53.69%
best case performance with lzo compression:
	average time to display: 858.586599ms
	standard deviation for time to display: 251.825619ms
	average time to display percent change: -2.48%
lzo snap size: 390.28 MiB (change of +39.02%)

```