### PR TITLE
cmd/etrace/exec: add sudo to snap remove

### DIFF
--- a/cmd/etrace/cmd_exec.go
+++ b/cmd/etrace/cmd_exec.go
@@ -283,7 +283,12 @@ func (x *cmdExec) Execute(args []string) error {
 			}
 
 			// now remove the snap
-			removeOut, err := exec.Command("snap", "remove", snapName).CombinedOutput()
+			removeCmd := exec.Command("snap", "remove", snapName)
+			if err := commands.AddSudoIfNeeded(removeCmd); err != nil {
+				return fmt.Errorf("failed to add sudo if needed: %v", err)
+			}
+
+			removeOut, err := removeCmd.CombinedOutput()
 			if err != nil {
 				return fmt.Errorf("failed to remove snap %s: %v (%s)", snapName, err, string(removeOut))
 			}


### PR DESCRIPTION
Snap remove can only be run as the user if the user is logged in.

See also https://forum.snapcraft.io/t/new-etrace-features/26300/25